### PR TITLE
Update nodeconfig-vsphere.yaml

### DIFF
--- a/charts/templates/nodeconfig-vsphere.yaml
+++ b/charts/templates/nodeconfig-vsphere.yaml
@@ -20,7 +20,7 @@ cfgparam:
 {{- end }}
 cloneFrom: {{ $nodepool.cloneFrom }}
 cloudConfig: |
-{{ $nodepool.cloudConfig | indent 2 }}
+{{ toYaml $nodepool.cloudConfig | indent 2 }}
 cloudinit: {{ $nodepool.cloudinit }}
 contentLibrary: {{ $nodepool.contentLibrary }}
 cpuCount: {{ $nodepool.cpuCount | quote }}


### PR DESCRIPTION
This PR fixes a missing `toYaml` in `nodeconfig-vsphere.yaml`. Without this helm is not able to render from `values-vsphere.yaml`,

Have a nice day!